### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#finna-widget
+# finna-widget
 
 A widget for displaying records (currently only images) from the Finna API in Skosmos/Finto.
 


### PR DESCRIPTION
GitHub's markdown is a bit special, and requires at least one space before the hash and the heading, or it displays a paragraph.